### PR TITLE
Enforce Bowtie-only JSON validation and surfacing

### DIFF
--- a/src/data/example.json
+++ b/src/data/example.json
@@ -1,43 +1,44 @@
 {
-  "fruits": [
+  "hazard": "Chemical spill during storage",
+  "element": "Bulk solvent tank",
+  "threat_actions": [
     {
-      "name": "Apple",
-      "color": "#FF0000",
-      "details": {
-        "type": "Pome",
-        "season": "Fall"
-      },
-      "nutrients": {
-        "calories": 52,
-        "fiber": "2.4g",
-        "vitaminC": "4.6mg"
-      }
+      "name": "Overfilling",
+      "actors": "Operations team",
+      "IEF": "Manual transfer continues after high level alarm",
+      "controls": [
+        { "name": "Independent high-level alarm", "status": "operational" },
+        { "name": "Automatic inlet shutoff valve", "status": "operational" }
+      ]
     },
     {
-      "name": "Banana",
-      "color": "#FFFF00",
-      "details": {
-        "type": "Berry",
-        "season": "Year-round"
-      },
-      "nutrients": {
-        "calories": 89,
-        "fiber": "2.6g",
-        "potassium": "358mg"
-      }
+      "name": "Corrosion",
+      "actors": "Chemical exposure",
+      "IEF": "External corrosion reduces wall thickness",
+      "controls": [
+        { "name": "Protective coating inspections", "status": "scheduled" },
+        { "name": "Cathodic protection", "status": "operational" }
+      ]
+    }
+  ],
+  "consequences": [
+    {
+      "name": "Release to environment",
+      "severity": "Major",
+      "failure_mode": "Loss of containment",
+      "safeguards": [
+        { "name": "Secondary containment berm", "status": "operational" },
+        { "name": "Emergency spill response team", "status": "trained" }
+      ]
     },
     {
-      "name": "Orange",
-      "color": "#FFA500",
-      "details": {
-        "type": "Citrus",
-        "season": "Winter"
-      },
-      "nutrients": {
-        "calories": 47,
-        "fiber": "2.4g",
-        "vitaminC": "53.2mg"
-      }
+      "name": "Fire escalation",
+      "severity": "Severe",
+      "failure_mode": "Vapor cloud ignition",
+      "safeguards": [
+        { "name": "Fixed foam suppression system", "status": "operational" },
+        { "name": "Emergency shutdown procedures", "status": "documented" }
+      ]
     }
   ]
 }

--- a/src/features/editor/BottomBar.tsx
+++ b/src/features/editor/BottomBar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Flex, Menu, Popover, Text } from "@mantine/core";
+import { Flex, Menu, Text } from "@mantine/core";
 import styled from "styled-components";
 import { event as gaEvent } from "nextjs-google-analytics";
 import { BiSolidDockLeft } from "react-icons/bi";
@@ -9,6 +9,7 @@ import { VscCheck, VscError, VscRunAll, VscSync, VscSyncIgnored } from "react-ic
 import { formats } from "../../enums/file.enum";
 import useConfig from "../../store/useConfig";
 import useFile from "../../store/useFile";
+import { useModal } from "../../store/useModal";
 import useGraph from "./views/GraphView/stores/useGraph";
 
 const StyledBottomBar = styled.div`
@@ -84,6 +85,7 @@ export const BottomBar = () => {
   const fullscreen = useGraph(state => state.fullscreen);
   const setFormat = useFile(state => state.setFormat);
   const currentFormat = useFile(state => state.format);
+  const setVisible = useModal(state => state.setVisible);
 
   const toggleEditor = () => {
     toggleFullscreen(!fullscreen);
@@ -94,6 +96,12 @@ export const BottomBar = () => {
     if (data?.name) window.document.title = `${data.name} | JSON Crack`;
   }, [data]);
 
+  React.useEffect(() => {
+    if (typeof error === "string" && error.trim().length > 0) {
+      setVisible("BowtieErrorModal", true);
+    }
+  }, [error, setVisible]);
+
   return (
     <StyledBottomBar>
       <StyledLeft>
@@ -102,19 +110,12 @@ export const BottomBar = () => {
         </StyledBottomBarItem>
         <StyledBottomBarItem>
           {error ? (
-            <Popover width="auto" shadow="md" position="top" withArrow>
-              <Popover.Target>
-                <Flex align="center" gap={2}>
-                  <VscError color="red" />
-                  <Text c="red" fw={500} fz="xs">
-                    Invalid
-                  </Text>
-                </Flex>
-              </Popover.Target>
-              <Popover.Dropdown style={{ pointerEvents: "none" }}>
-                <Text size="xs">{error}</Text>
-              </Popover.Dropdown>
-            </Popover>
+            <Flex align="center" gap={2}>
+              <VscError color="red" />
+              <Text c="red" fw={500} fz="xs">
+                Invalid
+              </Text>
+            </Flex>
           ) : (
             <Flex align="center" gap={2}>
               <VscCheck />

--- a/src/features/modals/BowtieErrorModal/index.tsx
+++ b/src/features/modals/BowtieErrorModal/index.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import type { ModalProps } from "@mantine/core";
+import { Button, Modal, Stack, Text } from "@mantine/core";
+import useFile from "../../../store/useFile";
+import { useModal } from "../../../store/useModal";
+
+export const BowtieErrorModal = ({ opened, onClose }: ModalProps) => {
+  const error = useFile(state => state.error);
+  const clearError = useFile(state => state.clearError);
+  const setVisible = useModal(state => state.setVisible);
+
+  const handleClose = React.useCallback(() => {
+    clearError();
+    setVisible("BowtieErrorModal", false);
+    onClose?.();
+  }, [clearError, onClose, setVisible]);
+
+  return (
+    <Modal title="Bowtie inválido" opened={opened} onClose={handleClose} centered size="lg">
+      <Stack gap="md">
+        <Text>{error}</Text>
+        <Button onClick={handleClose}>Cerrar</Button>
+      </Stack>
+    </Modal>
+  );
+};

--- a/src/features/modals/index.ts
+++ b/src/features/modals/index.ts
@@ -6,3 +6,4 @@ export { SchemaModal } from "./SchemaModal";
 export { JQModal } from "./JQModal";
 export { TypeModal } from "./TypeModal";
 export { JPathModal } from "./JPathModal";
+export { BowtieErrorModal } from "./BowtieErrorModal";

--- a/src/lib/utils/validateBowtie.ts
+++ b/src/lib/utils/validateBowtie.ts
@@ -1,0 +1,102 @@
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const validateStringField = (path: string, value: unknown, errors: string[]) => {
+  if (!isNonEmptyString(value)) {
+    errors.push(`${path} debe ser un string no vacío.`);
+  }
+};
+
+const validateNestedArray = (
+  data: unknown,
+  path: string,
+  errors: string[],
+  callback: (value: Record<string, unknown>, index: number) => void
+) => {
+  if (!Array.isArray(data) || data.length === 0) {
+    errors.push(`${path} debe ser un array con al menos un elemento.`);
+    return;
+  }
+
+  data.forEach((item, index) => {
+    if (!isPlainObject(item)) {
+      errors.push(`${path}[${index}] debe ser un objeto.`);
+      return;
+    }
+
+    callback(item as Record<string, unknown>, index);
+  });
+};
+
+export const validateBowtieJson = (value: unknown): string[] => {
+  const errors: string[] = [];
+
+  if (!isPlainObject(value)) {
+    errors.push("El Bowtie debe ser un objeto JSON.");
+    return errors;
+  }
+
+  const bowtie = value as Record<string, unknown>;
+
+  validateStringField("Bowtie.hazard", bowtie.hazard, errors);
+  validateStringField("Bowtie.element", bowtie.element, errors);
+
+  validateNestedArray(bowtie.threat_actions, "Bowtie.threat_actions", errors, (threat, index) => {
+    validateStringField(`Bowtie.threat_actions[${index}].name`, threat.name, errors);
+    validateStringField(`Bowtie.threat_actions[${index}].actors`, threat.actors, errors);
+    validateStringField(`Bowtie.threat_actions[${index}].IEF`, threat.IEF, errors);
+
+    validateNestedArray(
+      threat.controls,
+      `Bowtie.threat_actions[${index}].controls`,
+      errors,
+      (control, controlIndex) => {
+        validateStringField(
+          `Bowtie.threat_actions[${index}].controls[${controlIndex}].name`,
+          control.name,
+          errors
+        );
+        validateStringField(
+          `Bowtie.threat_actions[${index}].controls[${controlIndex}].status`,
+          control.status,
+          errors
+        );
+      }
+    );
+  });
+
+  validateNestedArray(bowtie.consequences, "Bowtie.consequences", errors, (consequence, index) => {
+    validateStringField(`Bowtie.consequences[${index}].name`, consequence.name, errors);
+    validateStringField(`Bowtie.consequences[${index}].severity`, consequence.severity, errors);
+    validateStringField(
+      `Bowtie.consequences[${index}].failure_mode`,
+      consequence.failure_mode,
+      errors
+    );
+
+    validateNestedArray(
+      consequence.safeguards,
+      `Bowtie.consequences[${index}].safeguards`,
+      errors,
+      (safeguard, safeguardIndex) => {
+        validateStringField(
+          `Bowtie.consequences[${index}].safeguards[${safeguardIndex}].name`,
+          safeguard.name,
+          errors
+        );
+        validateStringField(
+          `Bowtie.consequences[${index}].safeguards[${safeguardIndex}].status`,
+          safeguard.status,
+          errors
+        );
+      }
+    );
+  });
+
+  return errors;
+};
+
+export default validateBowtieJson;


### PR DESCRIPTION
## Summary
- add a Bowtie JSON validator and use it in the JSON adapter so only compliant files are accepted
- update the file store to surface validation errors through a new Bowtie error modal and restrict imports to JSON
- replace the bundled example with a valid Bowtie document for the default view

## Testing
- pnpm lint
- pnpm test *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68caf9af6be4832e862a72812dc6c4cd